### PR TITLE
Halloween image fix, and better explanation in readme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - initial-site
+      - image-resource
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ menu defined in `hugo.toml`, either as a top level item, or sub-menu item (by de
 organised into subfolders as required.
 
 Images should be saved to `static/img` which are deployed to a top-level `img` folder. 
-When including links to images, you'll need to set the path to this relative to the page or post you're working in e.g. to link
+When including links to images, you'll need to set the image path relative to the page or post you're working in e.g. to link
 to `img/frights_and_bites.png` from `page/social.md`, the path is `../../img/frights_and_bites.png`.
 
 ## Local testing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ To add a static page, create a new file in the `/content/page` folder. You can l
 menu defined in `hugo.toml`, either as a top level item, or sub-menu item (by defining its `parent`). Pages can be 
 organised into subfolders as required.
 
-Images should be saved to `static/img`
+Images should be saved to `static/img` which are deployed to a top-level `img` folder. 
+When including links to images, you'll need to set the path to this relative to the page or post you're working in e.g. to link
+to `img/frights_and_bites.png` from `page/social.md`, the path is `../../img/frights_and_bites.png`.
 
 ## Local testing
 

--- a/content/page/social.md
+++ b/content/page/social.md
@@ -8,7 +8,7 @@
 
 * Frights and bites bake-off 
 
-![frights and bites AI generated poster](/img/frights_and_bites.png)
+![frights and bites AI generated poster](img/frights_and_bites.png)
 
 12.30 - 13.30 24th October
 

--- a/content/page/social.md
+++ b/content/page/social.md
@@ -8,7 +8,7 @@
 
 * Frights and bites bake-off 
 
-![frights and bites AI generated poster](img/frights_and_bites.png)
+![frights and bites AI generated poster](../../img/frights_and_bites.png)
 
 12.30 - 13.30 24th October
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseurl = "https://username.github.io"
+baseurl = "https://mrc-ide.github.io/noticeboard/"
 DefaultContentLanguage = "en"
 title = "DIDE noticeboard"
 # Using theme as git submodule


### PR DESCRIPTION
There's a couple of ways of tackling this, using BaseUrl or image resource, but just getting the relative path right seems like the simplest approach. 

This branch with fix deployed to pages now. 